### PR TITLE
feat: Add bit manipulation functions and overhaul documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Fernando Montes de Oca (fmol1975@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,125 +1,261 @@
-## La documentacion no esta actualizada!!!.
-## Utilidad para trabajar con distintos tipos de datos en paquetes de 16 bit.
+# DataConversion Library
 
-Cada registro de retencion trabaja con palabras de 16 bits
+## Overview
 
-En las tablas de los registros Modbus aparecen los siguientes tipos de datos:
+Utility for working with different data types in 16-bit packages. Each holding register works with 16-bit words.
 
-| Nombre   | Descripción                              | Alcance                                                |
-| -------- | ----------------------------------------- | ------------------------------------------------------ |
-| UINT     | Entero de 16 bits sin signo (1 registro)  | 0...65535                                              |
-| INT      | Entero de 16 bits con signo (1 registro)  | -32768...+32767                                        |
-| UINT32   | Entero de 32 bits sin signo (2 registros) | 0...4 294 967 295                                      |
-| INT32    | Entero de 32 bits con signo (2 registros) | -2 147 483 648...+2 147 483 647                        |
-| INT64    | Entero de 64 bits con signo (4 registros) | -9 223 372 036 854 775 808...9 223 372 036 854 775 807 |
-| Float32  | Valor de 32 bits (2 registros)            | -3,4028E+38...+3,4028E+38                              |
-| ASCII    | Carácter alfanumérico de 8 bits         | Tabla de caracteres ASCII                              |
-| BITMAP   | Campo de 16 bits (1 palabra)              | –                                                     |
-| DATETIME | Consultar a continuación                 | –                                                     |
+This library provides functions to convert standard C++ data types to and from arrays of `uint16_t` (16-bit words). This is particularly useful for communication protocols like Modbus, where data is often exchanged in 16-bit registers. The library helps in packing larger data types (like 32-bit integers or floats) into multiple 16-bit words and unpacking them back.
 
-Tabla 1.
+## Features
 
-**NOTA:**
+*   Supports conversion for various data types:
+    *   `int8_t`
+    *   `uint8_t`
+    *   `int16_t` (implied, as `uint16_t` is the base)
+    *   `uint16_t` (base unit)
+    *   `int32_t`
+    *   `uint32_t`
+    *   `float` (32-bit floating point)
+    *   `int64_t`
+    *   `uint64_t`
+    *   `double` (64-bit floating point)
+*   Provides bit manipulation functions for `uint16_t` data:
+    *   `setBit(data, bitPosition)`: Sets a specific bit.
+    *   `clearBit(data, bitPosition)`: Clears a specific bit.
+    *   `readBit(data, bitPosition)`: Reads the state of a specific bit.
+    *   `toggleBit(data, bitPosition)`: Toggles a specific bit.
 
-* Float32Tipo de datos : flotante de precisión sencilla con bit de signo, exponente de 8 bits, mantisa de 23 bits (real normalizado positivo y negativo)
-* Para los datos de tipo ASCII, el orden de transmisión de los caracteres de las palabras (registros de 16 bits) es el siguiente:
-* Carácter n de peso no significativo
-* Carácter n + 1 de peso significativo
-* Todos los registros (de 16 bits o 2 bytes) se transmiten con la codificación Big Endian:
-* El byte más significativo se transmite en primer lugar.
-* El byte menos significativo se transmite en segundo lugar.
-* Las variables de 32 bits guardadas en dos palabras de 16 bits (por ejemplo, medidores de consumo) se encuentran en formato Big Endian:
-* La palabra de peso significativo se transmite primero y, a continuación, la de peso no significativo.
-* Las variables de 64 bits guardadas en cuatro palabras de 16 bits (por ejemplo, fechas) se encuentran en formato Big Endian:
-* La palabra de peso significativo se transmite primero y así sucesivamente.
+## Modbus Data Representation
 
-#### Comensemos con la explicacion.
+In Modbus register tables, the following data types commonly appear:
 
-No hay un estandar definido para el alamcenamiento de valores mayores a 16 bits en los registros Modbus pero si una convencion.
-Aqui una explicacion grafica de como se almacenan normalmente los registros de 32 bits en 2 registros de 16 bits.
+| Name     | Description                              | Range                                                   |
+| -------- | ---------------------------------------- | ------------------------------------------------------- |
+| UINT     | Unsigned 16-bit integer (1 register)   | 0...65535                                               |
+| INT      | Signed 16-bit integer (1 register)     | -32768...+32767                                         |
+| UINT32   | Unsigned 32-bit integer (2 registers)  | 0...4,294,967,295                                       |
+| INT32    | Signed 32-bit integer (2 registers)    | -2,147,483,648...+2,147,483,647                         |
+| INT64    | Signed 64-bit integer (4 registers)    | -9,223,372,036,854,775,808...9,223,372,036,854,775,807  |
+| Float32  | 32-bit floating point value (2 registers) | -3.4028E+38...+3.4028E+38                               |
+| ASCII    | 8-bit alphanumeric character           | ASCII character table                                   |
+| BITMAP   | 16-bit field (1 word)                  | –                                                       |
+| DATETIME | See below                                | –                                                       |
+Table 1: Modbus Data Types
 
-![figura1](./resource/figura1.png)
+**NOTE:**
 
-Figura 1.
+*   `Float32` Data type: single-precision float with a sign bit, 8-bit exponent, 23-bit mantissa (positive and negative normalized real).
+*   For ASCII data type, the transmission order of characters in words (16-bit registers) is as follows:
+    *   Character n of non-significant weight
+    *   Character n + 1 of significant weight
+*   All registers (16-bit or 2 bytes) are typically transmitted with Big Endian encoding for the bytes within the word:
+    *   The most significant byte is transmitted first.
+    *   The least significant byte is transmitted second.
+*   32-bit variables stored in two 16-bit words (e.g., consumption meters) are in Big Endian word order:
+    *   The most significant word is transmitted first, then the least significant word.
+*   64-bit variables stored in four 16-bit words (e.g., dates) are in Big Endian word order:
+    *   The most significant word is transmitted first, and so on.
 
-**Fuentes:**
+**Endianness Clarification:**
 
-* [Schneider Electric](https://product-help.schneider-electric.com/ED/PowerTag/Smartlink_SIB/EDMS/DOCA0123ES/DOCA0123xx/Tables_of_Modbus_Registers/Tables_of_Modbus_Registers-4.htm "Tipos de datos")
-* [National Instruments](https://www.ni.com/en-us/innovations/white-papers/14/the-modbus-protocol-in-depth.html "¿Qué es el protocolo Modbus y cómo funciona?")
-* [Industruino](https://industruino.com/blog/our-news-1/post/modbus-tips-for-industruino-26#blog_content "Split 32-bit values into 16-bit registers")
+This library implements **Big Endian word order** for multi-register values. This means that for data types like `uint32_t`, `float`, `int64_t`, etc., which are split into multiple `uint16_t` words, the library arranges these words such that the Most Significant Word (MSW) comes first in the resulting array.
 
-Palabra de 8 bits usados por ESP
+For example, when splitting a `uint32_t` into two `uint16_t`s, `word[0]` will be the MSW and `word[1]` will be the Least Significant Word (LSW). Similarly, when merging, `word[0]` is expected to be the MSW.
 
-| Tipo        | atmega328p | esp32 | rpi 3 arm32 | Win x64 x64 MSC++ | Win x64 G++ | linux x64 g++ |
-| ----------- | ---------- | ----- | ----------- | ----------------- | ----------- | ------------- |
-| bool        | 1          | 1     | 1           | 1                 | 1           | 1             |
-| char        | 1          | 1     | 1           | 1                 | 1           | 1             |
-| int         | 2          | 4     | 4           | 4                 | 4           | 4             |
-| long        | 4          | 4     | 4           | 4                 | 4           | 8             |
-| long long   | 8          | 8     | 8           | 8                 | 8           | 8             |
-| float       | 4          | 4     | 4           | 4                 | 4           | 4             |
-| double      | 4          | 8     | 8           | 8                 | 8           | 8             |
-| long double | 4          | 8     | 8           | 8                 | 16          | 16            |
+It is crucial to understand that this library **assumes the underlying Modbus communication stack handles the transmission of each individual 16-bit word in Big Endian byte order** (Most Significant Byte first). Microcontrollers like Arduino and ESP32 are typically Little Endian. This means that while the library correctly orders the *words*, the byte order *within each word* must be managed by the Modbus stack (e.g., by swapping bytes before transmission if the stack doesn't do it automatically on Little Endian systems). Most Modbus libraries for Arduino/ESP32 handle this byte swap automatically.
 
-Tabla 2.
+Let's start with the explanation.
 
-Fuente: [LUIS LLAMAS](https://www.luisllamas.es/tamanos-de-variables-en-esp32-arduino-raspberry-pi-windows-y-linux/ "TAMAÑOS DE VARIABLES EN ESP32, ARDUINO, RASPBERRY PI, WINDOWS Y LINUX")
+There is no defined standard for storing values greater than 16 bits in Modbus registers, but there is a convention. Here is a graphical explanation of how 32-bit registers are normally stored in 2 16-bit registers.
 
-Segun los datos obtenidos en la tabla 2, si pasamos los valores a 16 bits quedarian:
+![Figure 1: Modbus 32-bit register storage](resource/figura1.png)
 
+Figure 1.
 
-Palabra de 8 bits usados por ESP
+**Sources:**
 
-| Tipo        | atmega328p | esp32 |
-| ----------- | ---------- | ----- |
-| bool        | 0.5        | 0.5   |
-| char        | 0.5        | 0.5   |
-| int         | 1          | 1     |
-| long        | 2          | 1     |
-| long long   | 4          | 4     |
-| float       | 2          | 2     |
-| double      | 2          | 4     |
-| long double | 2          | 4     |
+*   [Schneider Electric](https://product-help.schneider-electric.com/ED/PowerTag/Smartlink_SIB/EDMS/DOCA0123ES/DOCA0123xx/Tables_of_Modbus_Registers/Tables_of_Modbus_Registers-4.htm "Data Types")
+*   [National Instruments](https://www.ni.com/en-us/innovations/white-papers/14/the-modbus-protocol-in-depth.html "What is Modbus Protocol and How Does It Work?")
+*   [Industruino](https://industruino.com/blog/our-news-1/post/modbus-tips-for-industruino-26#blog_content "Split 32-bit values into 16-bit registers")
 
-Tabla 3.
+## Data Type Sizes and Conversions
 
-Entonces segun la tabla 3 vamos a tener las siguientes tareas o funciones.
+The size of standard C++ data types can vary by platform. The following table shows typical sizes on different architectures:
 
-Leer y escribir el registro de retencion 0 bit a bit.
+| Type        | atmega328p (Arduino Uno) | esp32 | rpi 3 (ARM32) | Win x64 (MSC++) | Win x64 (G++) | Linux x64 (g++) |
+| ----------- | ------------------------ | ----- | ------------- | ----------------- | ------------- | --------------- |
+| bool        | 1 byte                   | 1 byte| 1 byte        | 1 byte            | 1 byte        | 1 byte          |
+| char        | 1 byte                   | 1 byte| 1 byte        | 1 byte            | 1 byte        | 1 byte          |
+| int         | 2 bytes                  | 4 bytes| 4 bytes        | 4 bytes            | 4 bytes        | 4 bytes          |
+| long        | 4 bytes                  | 4 bytes| 4 bytes        | 4 bytes            | 4 bytes        | 8 bytes          |
+| long long   | 8 bytes                  | 8 bytes| 8 bytes        | 8 bytes            | 8 bytes        | 8 bytes          |
+| float       | 4 bytes                  | 4 bytes| 4 bytes        | 4 bytes            | 4 bytes        | 4 bytes          |
+| double      | 4 bytes (same as float)  | 8 bytes| 8 bytes        | 8 bytes            | 8 bytes        | 8 bytes          |
+| long double | 4 bytes                  | 8 bytes| 8 bytes        | 8 bytes            | 16 bytes       | 16 bytes         |
+Table 2: Data type sizes (in bytes) across different platforms.
 
-Leer y escribir un valor uint en el registro 1.
+Source: [LUIS LLAMAS](https://www.luisllamas.es/tamanos-de-variables-en-esp32-arduino-raspberry-pi-windows-y-linux/ "VARIABLE SIZES IN ESP32, ARDUINO, RASPBERRY PI, WINDOWS AND LINUX")
 
-Leer y escribir un valor int en el registro 2.
+Based on Table 2, if we convert these sizes to the number of 16-bit words required for ESP32:
 
-Leer y escribir un valor ulong en el registro 3.
+| Type        | atmega328p (16-bit words) | esp32 (16-bit words) |
+| ----------- | ------------------------- | -------------------- |
+| bool        | 0.5                       | 0.5                  |
+| char        | 0.5                       | 0.5                  |
+| int         | 1                         | 2 (ESP32 int is 4 bytes) |
+| long        | 2                         | 2 (ESP32 long is 4 bytes) |
+| long long   | 4                         | 4                    |
+| float       | 2                         | 2                    |
+| double      | 2 (double is float on Uno)| 4                    |
+| long double | 2                         | 4                    |
+Table 3: Data types represented in number of 16-bit words.
 
-Leer y escribir un valor long en el registro 4.
+**Note:** Table 3 provides a conceptual mapping. This library primarily focuses on converting to/from `uint16_t` arrays, and the number of words depends on the source type's size (e.g., a 32-bit `float` will always use two `uint16_t` words).
 
-Leer y escribir un valor long long en el registro 5 y 6.
+The library supports conversions for:
+*   Reading and writing individual bits within a 16-bit word.
+*   Converting `uint8_t` and `int8_t` to/from a `uint16_t` (typically packing two 8-bit values into one 16-bit word, or one 8-bit value into a 16-bit word with padding).
+*   Converting `uint32_t`, `int32_t`, and `float` (32-bit) to/from two `uint16_t` words.
+*   Converting `uint64_t`, `int64_t`, and `double` (64-bit) to/from four `uint16_t` words.
 
-Leer y escribir un valor float en el registro 7 y 8.
+Min/Max values for common types:
 
-Leer y escribir un valor double en el registro 9 y 10.
+| Description                             | Minimum Value                                | Maximum Value                                |
+| --------------------------------------- | :-------------------------------------------: | :------------------------------------------: |
+| 16-bit Bitfield                         | `0b0000000000000000`                          | `0b1111111111111111`                         |
+| `uint16_t` (unsigned int)               | 0                                             | 65535                                        |
+| `int16_t` (signed int)                  | -32768                                        | 32767                                        |
+| `uint32_t` (unsigned long on ESP32)     | 0                                             | 4,294,967,295                                |
+| `int32_t` (signed long on ESP32)        | -2,147,483,648                                | 2,147,483,647                                |
+| `int64_t` (long long)                   | -9,223,372,036,854,775,808                    | 9,223,372,036,854,775,807                    |
+| `float` (32-bit)                        | approx. 1.18e-38 (7 significant digits)       | approx. 3.40e+38 (7 significant digits)      |
+| `double` (64-bit on ESP32)              | approx. 2.23e-308 (15-16 significant digits)  | approx. 1.79e+308 (15-16 significant digits) |
 
-Leer y escribir un valor long double en el registro 11 y 12.
+## Floating Point Precision
 
-| Nombres                                                      |       Valor minimo       |       Valor maximo       |  |  |
-| ------------------------------------------------------------ | :-----------------------: | :----------------------: | - | - |
-| Leer y escribir el registro de retencion 0 bit a bit.        |     0000000000000000     |     1111111111111111     |  |  |
-| Leer y escribir un valor uint en el registro 1.              |             0             |          65535          |  |  |
-| Leer y escribir un valor int en el registro 2.               |          -32768          |          32767          |  |  |
-| Leer y escribir un valor ulong en el registro 3.             |             0             |        4294967295        |  |  |
-| Leer y escribir un valor long en el registro 4.              |        -2147483648        |        2147483647        |  |  |
-| Leer y escribir un valor long long en el registro 5 y 6.     |   -9223372036854775808   |   9223372036854775807   |  |  |
-| Leer y escribir un valor float en el registro 7 y 8.         |  1.18e-38 ( 7-dígitos)  |  3.40e38 ( 7-dígitos)  |  |  |
-| Leer y escribir un valor double en el registro 9 y 10.       | 2.23e-308 (15-dígitos) | 1.79e308 (15-dígitos) |  |  |
-| Leer y escribir un valor long double en el registro 11 y 12. | 3.37e-4932 (18-dígitos) | 1.18e4932 (18-dígitos) |  |  |
+The precision of a floating-point number (float) refers to how many significant digits it can represent without loss of accuracy. In the case of single-precision floating-point numbers (float), they can accurately represent between 6 and 7 decimal digits. This means that if you try to store a number with more than 7 decimal digits in a float variable, you may lose precision, and the stored number may not be exactly equal to the original number.
 
+It is important to note that precision refers to the total number of digits, not just the digits to the right of the decimal point. For example, the number 123456.789 has 9 total digits, so if you try to store it in a float variable, you may lose precision.
 
-La precisión de un número de punto flotante (float) se refiere a cuántos dígitos significativos puede representar sin perder precisión. En el caso de los números de punto flotante de precisión simple (float), pueden representar con precisión entre 6 y 7 dígitos decimales. Esto significa que si intentas almacenar un número con más de 7 dígitos decimales en una variable float, es posible que pierdas precisión y el número almacenado no sea exactamente igual al número original.
+If you need to represent numbers with more than 7 decimal digits accurately, you can use the `double` data type, which has a precision of about 15-16 decimal digits.
 
-Es importante tener en cuenta que la precisión se refiere al número total de dígitos, no solo a los dígitos a la derecha del punto decimal. Por ejemplo, el número 123456.789 tiene 9 dígitos en total, por lo que si intentas almacenarlo en una variable float, es posible que pierdas precisión.
+The sign is not counted as a digit of precision in a float variable. The precision of a float variable refers to the number of significant digits it can represent without losing accuracy. The sign of a number (positive or negative) is stored separately and does not affect the precision of the number.
 
-Si necesitas representar números con más de 7 dígitos decimales con precisión, puedes usar el tipo de dato double, que tiene una precisión de alrededor de 15-16 dígitos decimales.
+## Installation
 
-El signo no se cuenta como un dígito de precisión en una variable float. La precisión de una variable float se refiere al número de dígitos significativos que puede representar sin perder precisión. El signo de un número (positivo o negativo) se almacena por separado y no afecta la precisión del número.
+### Arduino Library Manager
+This library is not yet registered with the Arduino Library Manager. You can install it manually or by importing the .zip file.
+
+### Importing .zip
+1.  Download the latest release as a .zip file from the GitHub repository.
+2.  In the Arduino IDE, go to `Sketch` > `Include Library` > `Add .ZIP Library...`.
+3.  Select the downloaded .zip file.
+
+### Manual Installation
+1.  Clone this repository or download it as a .zip file and extract it.
+2.  Move the extracted folder (should be named `DataConversion` or similar) to your Arduino libraries folder. This is typically found in:
+    *   Windows: `Documents\Arduino\libraries\`
+    *   macOS: `~/Documents/Arduino/libraries/`
+    *   Linux: `~/Arduino/libraries/`
+3.  Restart the Arduino IDE.
+
+## Usage
+
+Here are some basic examples of how to use the library:
+
+```cpp
+#include <Arduino.h>
+#include <DataConversion.h>
+
+void setup() {
+  Serial.begin(115200);
+
+  // Example 1: Splitting a uint32_t into two uint16_t words
+  uint32_t myUint32 = 0xABCDEF12;
+  uint16_t words32[2];
+  DataConversion::splitUint32ToUint16(myUint32, words32[0], words32[1]);
+  Serial.print("Original uint32_t: 0x");
+  Serial.println(myUint32, HEX);
+  Serial.print("Word 0 (MSW): 0x");
+  Serial.print(words32[0], HEX);
+  Serial.print(", Word 1 (LSW): 0x");
+  Serial.println(words32[1], HEX); // Expected: words32[0]=0xABCD, words32[1]=0xEF12
+
+  // Example 2: Merging two uint16_t words into a float
+  uint16_t floatWords[2];
+  floatWords[0] = 0x41F0; // MSW for 30.0f (approx)
+  floatWords[1] = 0x0000; // LSW
+  float myFloat = DataConversion::mergeUint16ToFloat32(floatWords[0], floatWords[1]);
+  Serial.print("\nMerged float: ");
+  Serial.println(myFloat);
+
+  // Example 3: Using bit manipulation - set a bit
+  uint16_t myRegister = 0b1010101010101010; // 43690
+  Serial.print("\nOriginal register: 0b");
+  Serial.println(myRegister, BIN);
+  
+  myRegister = DataConversion::setBit(myRegister, 3); // Set bit 3 (0-indexed)
+  Serial.print("After setting bit 3: 0b");
+  Serial.println(myRegister, BIN); // Expected: 0b1010101010101110 (43694)
+  
+  bool bit5status = DataConversion::readBit(myRegister, 5);
+  Serial.print("Status of bit 5: ");
+  Serial.println(bit5status ? "Set" : "Clear");
+
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+}
+```
+
+## API Reference
+
+The library provides a set of static methods within the `DataConversion` class.
+
+### Conversion Functions:
+These functions convert data to/from an array of `uint16_t` words, following Big Endian word order (Most Significant Word first).
+
+*   `static uint16_t mergeInt8ToUint16(int8_t firstI8Value, int8_t secondI8Value);`
+*   `static void splitUint16ToInt8(uint16_t valueUi16, int8_t &firstI8Value, int8_t &secondI8Value);`
+*   `static uint16_t mergeUint8ToUint16(uint8_t firstUi8Value, uint8_t secondUi8Value);`
+*   `static void splitUint16ToUint8(uint16_t valueUi16, uint8_t &firstUi8Value, uint8_t &secondUi8Value);`
+*   `static int32_t mergeUint16ToInt32(uint16_t ui16part1, uint16_t ui16part2);`
+*   `static void splitInt32ToUint16(int32_t valueI32, uint16_t &ui16part1, uint16_t &ui16part2);`
+*   `static uint32_t mergeUint16ToUint32(uint16_t ui16part1, uint16_t ui16part2);`
+*   `static void splitUint32ToUint16(uint32_t valueUi32, uint16_t &ui16part1, uint16_t &ui16part2);`
+*   `static float mergeUint16ToFloat32(uint16_t ui16part1, uint16_t ui16part2);`
+*   `static void splitFloat32ToUint16(float valueF32, uint16_t &ui16part1, uint16_t &ui16part2);`
+*   `static int64_t mergeUint16ToInt64(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4);`
+*   `static void splitInt64ToUint16(int64_t val, uint16_t &p1, uint16_t &p2, uint16_t &p3, uint16_t &p4);`
+*   `static uint64_t mergeUint16ToUint64(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4);`
+*   `static void splitUint64ToUint16(uint64_t val, uint16_t &p1, uint16_t &p2, uint16_t &p3, uint16_t &p4);`
+*   `static double mergeUint16ToDouble(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4);`
+*   `static void splitDoubleToUint16(double val, uint16_t &p1, uint16_t &p2, uint16_t &p3, uint16_t &p4);`
+
+### Bit Manipulation Functions (for `uint16_t`):
+*   `static uint16_t setBit(uint16_t data, uint8_t bitPosition);`
+*   `static uint16_t clearBit(uint16_t data, uint8_t bitPosition);`
+*   `static bool readBit(uint16_t data, uint8_t bitPosition);`
+*   `static uint16_t toggleBit(uint16_t data, uint8_t bitPosition);`
+
+Detailed API documentation is available in the Doxygen comments within `DataConversion.h`.
+
+## Examples
+
+The library includes several examples in the `src/Examples/` directory to demonstrate its usage:
+
+*   **`ExampleAll.ino`**: A comprehensive demonstration showing how to use all merge and split functions for various data types. It also includes usage of the bit manipulation functions.
+*   **`NewBitManipulation.ino`**: Specifically highlights the usage of the new bit manipulation functions (`setBit`, `clearBit`, `readBit`, `toggleBit`).
+*   **`BitTo16bitRegister.ino`**: Shows how to read and write individual bits of a 16-bit register using the library's bit manipulation functions. This example demonstrates their use as a platform-independent alternative to Arduino's built-in `bitRead()` and `bitWrite()`.
+*   Other examples (e.g., `SplitMergeInt8ToUInt16.ino`, `SplitMergeUint16ToFloat32.ino`, etc.) provide focused demonstrations for specific data type conversions.
+
+These examples are designed to be run on Arduino-compatible platforms like ESP32 or Arduino Uno and typically output results to the Serial Monitor.
+
+## Contributing
+
+Contributions are welcome! If you find any issues or have suggestions for improvements, please open an issue or submit a pull request on the GitHub repository.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/src/DataConversion.cpp
+++ b/src/DataConversion.cpp
@@ -144,3 +144,31 @@ void DataConversion::splitDoubleToUint16(double dblValue, uint16_t &dblPart1, ui
     dblPart3 = (uint16_t)(mergedValue >> 16);
     dblPart4 = (uint16_t)mergedValue;
 }
+
+// Sets a specific bit in a uint16_t value.
+uint16_t DataConversion::setBit(uint16_t data, uint8_t bitPosition)
+{
+    if (bitPosition >= 16) return data; // Or handle error appropriately
+    return data | (1 << bitPosition);
+}
+
+// Clears a specific bit in a uint16_t value.
+uint16_t DataConversion::clearBit(uint16_t data, uint8_t bitPosition)
+{
+    if (bitPosition >= 16) return data; // Or handle error appropriately
+    return data & ~(1 << bitPosition);
+}
+
+// Reads a specific bit from a uint16_t value.
+bool DataConversion::readBit(uint16_t data, uint8_t bitPosition)
+{
+    if (bitPosition >= 16) return false; // Or handle error appropriately
+    return (data >> bitPosition) & 1;
+}
+
+// Toggles a specific bit in a uint16_t value.
+uint16_t DataConversion::toggleBit(uint16_t data, uint8_t bitPosition)
+{
+    if (bitPosition >= 16) return data; // Or handle error appropriately
+    return data ^ (1 << bitPosition);
+}

--- a/src/DataConversion.h
+++ b/src/DataConversion.h
@@ -161,6 +161,42 @@ public:
      * @param dblPart4 Reference to the resulting fourth part.
      */
     static void splitDoubleToUint16(double dblValue, uint16_t &dblPart1, uint16_t &dblPart2, uint16_t &dblPart3, uint16_t &dblPart4);
+
+    /**
+     * Sets a specific bit in a uint16_t value.
+     *
+     * @param data The original uint16_t value.
+     * @param bitPosition The position of the bit to set (0-15).
+     * @return The uint16_t value with the specified bit set.
+     */
+    static uint16_t setBit(uint16_t data, uint8_t bitPosition);
+
+    /**
+     * Clears a specific bit in a uint16_t value.
+     *
+     * @param data The original uint16_t value.
+     * @param bitPosition The position of the bit to clear (0-15).
+     * @return The uint16_t value with the specified bit cleared.
+     */
+    static uint16_t clearBit(uint16_t data, uint8_t bitPosition);
+
+    /**
+     * Reads a specific bit from a uint16_t value.
+     *
+     * @param data The uint16_t value to read from.
+     * @param bitPosition The position of the bit to read (0-15).
+     * @return True if the bit is set (1), false if it is clear (0).
+     */
+    static bool readBit(uint16_t data, uint8_t bitPosition);
+
+    /**
+     * Toggles a specific bit in a uint16_t value.
+     *
+     * @param data The original uint16_t value.
+     * @param bitPosition The position of the bit to toggle (0-15).
+     * @return The uint16_t value with the specified bit toggled.
+     */
+    static uint16_t toggleBit(uint16_t data, uint8_t bitPosition);
 };
 
 #endif

--- a/src/Examples/BitTo16bitRegister.ino
+++ b/src/Examples/BitTo16bitRegister.ino
@@ -14,12 +14,12 @@
 */
 
 /*
-These write and read bit functions in variables are redundant.
-Since within the arduino framework they exist.
-bitRead() to read a specific bit from a variable.
-https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitread/
-bitWrite() to write a specific bit from a variable.
-https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitwrite/
+The DataConversion library now provides platform-independent bit manipulation functions:
+- DataConversion::readBit() to read a specific bit.
+- DataConversion::setBit() to set a specific bit.
+- DataConversion::clearBit() to clear a specific bit.
+- DataConversion::toggleBit() to toggle a specific bit.
+These can be used as an alternative to Arduino's built-in bitRead() and bitWrite().
 */
 #ifdef ESP8266
 #include <ESP8266WiFi.h>
@@ -28,9 +28,6 @@ https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitwrite/
 #endif
 #include <ModbusIP_ESP8266.h>
 #include <DataConversion.h>
-
-// Create an instance of the DataConversion class
-DataConversion dtConv;
 
 /*
 The enum function is used to create an enumerated data type.
@@ -106,11 +103,11 @@ void setup()
   mb.Hreg(NR_STATE_16BIT_REGISTER, state16bitRegister);
   Serial.println("Register 0 BIN= " + String(state16bitRegister, BIN));
   delay(1500);
-  state16bitRegister = bitWrite(state16bitRegister, 7, HIGH);
-  Serial.println("Write 1 in bit 7 ");
+  state16bitRegister = DataConversion::setBit(state16bitRegister, 7);
+  Serial.println("Write 1 in bit 7 using DataConversion::setBit()");
   delay(500);
-  state16bitRegister = bitWrite(state16bitRegister, 14, HIGH);
-  Serial.println("Write 1 in bit 14 ");
+  state16bitRegister = DataConversion::setBit(state16bitRegister, 14);
+  Serial.println("Write 1 in bit 14 using DataConversion::setBit()");
   delay(500);
   mb.Hreg(NR_STATE_16BIT_REGISTER, state16bitRegister);
   Serial.println("Writing value in modbus variable ");
@@ -142,23 +139,23 @@ void loop()
   // Yield to other tasks (if any)
   yield();
 
-  // Read individual bits from the state16bitRegister and store them in corresponding variables
-  bitValue00 = bitRead(state16bitRegister, 0);  // Read bit 0 from state16bitRegister and assign its value to bitValue00
-  bitValue01 = bitRead(state16bitRegister, 1);  // Read bit 1 from state16bitRegister and assign its value to bitValue01
-  bitValue02 = bitRead(state16bitRegister, 2);  // Read bit 2 from state16bitRegister and assign its value to bitValue02
-  bitValue03 = bitRead(state16bitRegister, 3);  // Read bit 3 from state16bitRegister and assign its value to bitValue03
-  bitValue04 = bitRead(state16bitRegister, 4);  // Read bit 4 from state16bitRegister and assign its value to bitValue04
-  bitValue05 = bitRead(state16bitRegister, 5);  // Read bit 5 from state16bitRegister and assign its value to bitValue05
-  bitValue06 = bitRead(state16bitRegister, 6);  // Read bit 6 from state16bitRegister and assign its value to bitValue06
-  bitValue07 = bitRead(state16bitRegister, 7);  // Read bit 7 from state16bitRegister and assign its value to bitValue07
-  bitValue08 = bitRead(state16bitRegister, 8);  // Read bit 8 from state16bitRegister and assign its value to bitValue08
-  bitValue09 = bitRead(state16bitRegister, 9);  // Read bit 9 from state16bitRegister and assign its value to bitValue09
-  bitValue10 = bitRead(state16bitRegister, 10); // Read bit 10 from state16bitRegister and assign its value to bitValue10
-  bitValue11 = bitRead(state16bitRegister, 11); // Read bit 11 from state16bitRegister and assign its value to bitValue11
-  bitValue12 = bitRead(state16bitRegister, 12); // Read bit 12 from state16bitRegister and assign its value to bitValue12
-  bitValue13 = bitRead(state16bitRegister, 13); // Read bit 13 from state16bitRegister and assign its value to bitValue13
-  bitValue14 = bitRead(state16bitRegister, 14); // Read bit 14 from state16bitRegister and assign its value to bitValue14
-  bitValue15 = bitRead(state16bitRegister, 15); // Read bit 15 from state16bitRegister and assign its value to bitValue15
+  // Read individual bits from the state16bitRegister and store them in corresponding variables using DataConversion::readBit()
+  bitValue00 = DataConversion::readBit(state16bitRegister, 0);  // Read bit 0
+  bitValue01 = DataConversion::readBit(state16bitRegister, 1);  // Read bit 1
+  bitValue02 = DataConversion::readBit(state16bitRegister, 2);  // Read bit 2
+  bitValue03 = DataConversion::readBit(state16bitRegister, 3);  // Read bit 3
+  bitValue04 = DataConversion::readBit(state16bitRegister, 4);  // Read bit 4
+  bitValue05 = DataConversion::readBit(state16bitRegister, 5);  // Read bit 5
+  bitValue06 = DataConversion::readBit(state16bitRegister, 6);  // Read bit 6
+  bitValue07 = DataConversion::readBit(state16bitRegister, 7);  // Read bit 7
+  bitValue08 = DataConversion::readBit(state16bitRegister, 8);  // Read bit 8
+  bitValue09 = DataConversion::readBit(state16bitRegister, 9);  // Read bit 9
+  bitValue10 = DataConversion::readBit(state16bitRegister, 10); // Read bit 10
+  bitValue11 = DataConversion::readBit(state16bitRegister, 11); // Read bit 11
+  bitValue12 = DataConversion::readBit(state16bitRegister, 12); // Read bit 12
+  bitValue13 = DataConversion::readBit(state16bitRegister, 13); // Read bit 13
+  bitValue14 = DataConversion::readBit(state16bitRegister, 14); // Read bit 14
+  bitValue15 = DataConversion::readBit(state16bitRegister, 15); // Read bit 15
 
   /* *Print the values of the variables* */
   // Get the current time

--- a/src/Examples/ExampleAll.ino
+++ b/src/Examples/ExampleAll.ino
@@ -14,12 +14,12 @@
 */
 
 /*
-These write and read bit functions in variables are redundant.
-Since within the arduino framework they exist.
-bitRead() to read a specific bit from a variable.
-https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitread/
-bitWrite() to write a specific bit from a variable.
-https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitwrite/
+The DataConversion library now provides platform-independent bit manipulation functions:
+- DataConversion::readBit() to read a specific bit.
+- DataConversion::setBit() to set a specific bit.
+- DataConversion::clearBit() to clear a specific bit.
+- DataConversion::toggleBit() to toggle a specific bit.
+These can be used as an alternative to Arduino's built-in bitRead() and bitWrite().
 */
 #ifdef ESP8266
 #include <ESP8266WiFi.h>
@@ -28,9 +28,6 @@ https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitwrite/
 #endif
 #include <ModbusIP_ESP8266.h>
 #include <DataConversion.h>
-
-// Create an instance of the DataConversion class
-DataConversion dtConv;
 
 /*
 The enum function is used to create an enumerated data type.
@@ -171,11 +168,11 @@ void setup()
   mb.Hreg(NR_STATE_16BIT_REGISTER, state16bitRegister);
   Serial.println("Register 0 BIN= " + String(state16bitRegister, BIN));
   delay(1500);
-  state16bitRegister = bitWrite(state16bitRegister, 7, HIGH);
-  Serial.println("Write 1 in bit 7 ");
+  state16bitRegister = DataConversion::setBit(state16bitRegister, 7);
+  Serial.println("Write 1 in bit 7 using DataConversion::setBit()");
   delay(500);
-  state16bitRegister = bitWrite(state16bitRegister, 14, HIGH);
-  Serial.println("Write 1 in bit 14 ");
+  state16bitRegister = DataConversion::setBit(state16bitRegister, 14);
+  Serial.println("Write 1 in bit 14 using DataConversion::setBit()");
   delay(500);
   mb.Hreg(NR_STATE_16BIT_REGISTER, state16bitRegister);
   Serial.println("Writing value in modbus variable ");
@@ -194,7 +191,7 @@ void setup()
   delay(500);
 
   // The mergeUint8ToUint16 function combines two 8-bit unsigned variables into one 16-bit unsigned variable.
-  varMergeInt8ToUInt16 = dtConv.mergeInt8ToUint16(varI8a, varI8b);
+  varMergeInt8ToUInt16 = DataConversion::mergeInt8ToUint16(varI8a, varI8b);
   Serial.println("Value merge varI8a + varI8b ");
   delay(500);
   // Write value to Modbus variable
@@ -216,7 +213,7 @@ void setup()
   delay(500);
 
   // The mergeUint8ToUint16 function combines two 8-bit unsigned variables into one 16-bit unsigned variable.
-  varMergeUint8ToUint16 = dtConv.mergeUint8ToUint16(varUi8a, varUi8b);
+  varMergeUint8ToUint16 = DataConversion::mergeUint8ToUint16(varUi8a, varUi8b);
   Serial.println("Value merge varUi8a + varUi8b ");
   delay(500);
   // Write value to Modbus variable
@@ -238,7 +235,7 @@ void setup()
   Serial.println("Write -2147483648 in variable varMergeUInt16ToInt32 ");
 
   // Splits a 32-bit integer into two 16-bit words.
-  dtConv.splitInt32ToUint16(varMergeUInt16ToInt32, varValueI32Part1, varValueI32Part2);
+  DataConversion::splitInt32ToUint16(varMergeUInt16ToInt32, varValueI32Part1, varValueI32Part2);
   delay(500);
   // Write value to Modbus variable
   mb.Hreg(NR_VALUEI32PART1, varValueI32Part1);
@@ -260,7 +257,7 @@ void setup()
   Serial.println("Write 4294967295 in variable varMergeUInt16ToInt32 ");
 
   // Separates a uint32_t value into two uint16_t values.
-  dtConv.splitUint32ToUint16(varMergeUInt16ToUInt32, varValueUi32Part1, varValueUi32Part2);
+  DataConversion::splitUint32ToUint16(varMergeUInt16ToUInt32, varValueUi32Part1, varValueUi32Part2);
   delay(500);
   // Write value to Modbus variable
   mb.Hreg(NR_VALUEUI32PART1, varValueUi32Part1);
@@ -279,7 +276,7 @@ void setup()
   varMergeUInt16ToFloat32 = 31.12345;
   Serial.println("Write 31.12345 in variable varMergeUInt16ToFloat32 ");
   // Separates a float value into two uint16_t values.
-  dtConv.splitFloat32ToUint16(varMergeUInt16ToFloat32, varFloatPart1, varFloatPart2);
+  DataConversion::splitFloat32ToUint16(varMergeUInt16ToFloat32, varFloatPart1, varFloatPart2);
   delay(500);
   // Write value to Modbus variable
   mb.Hreg(NR_FLOATPART1, varFloatPart1);
@@ -302,7 +299,7 @@ void setup()
   varMergeUInt16ToInt64 = -4294967295;
   Serial.println("Write -4294967295 in variable varMergeUInt16ToInt64 ");
   // Separates a int64 value into four uint16_t values.
-  dtConv.splitInt64ToUint16(varMergeUInt16ToInt64, varValueI64Part1, varValueI64Part2, varValueI64Part3, varValueI64Part4);
+  DataConversion::splitInt64ToUint16(varMergeUInt16ToInt64, varValueI64Part1, varValueI64Part2, varValueI64Part3, varValueI64Part4);
   delay(500);
   // Write value to Modbus variable
   mb.Hreg(NR_VALUEI64PART1, varValueI64Part1);
@@ -327,7 +324,7 @@ void setup()
   varMergeUInt16ToUInt64 = 84294967295;
   Serial.println("Write 84294967295 in variable varMergeUInt16ToUInt64 ");
   // Separates a int64 value into four uint16_t values.
-  dtConv.splitUint64ToUint16(varMergeUInt16ToUInt64, varValueUi64Part1, varValueUi64Part2, varValueUi64Part3, varValueUi64Part4);
+  DataConversion::splitUint64ToUint16(varMergeUInt16ToUInt64, varValueUi64Part1, varValueUi64Part2, varValueUi64Part3, varValueUi64Part4);
   delay(500);
   // Write value to Modbus variable
   mb.Hreg(NR_VALUEUI64PART1, varValueUi64Part1);
@@ -352,7 +349,7 @@ void setup()
   varMergeUInt16ToDouble = -12345.0123456789;
   Serial.println("Write -12345.023456789 in variable varMergeUInt16ToDouble ");
   // Separates a int64 value into four uint16_t values.
-  dtConv.splitDoubleToUint16(varMergeUInt16ToDouble, varValueDbPart1, varValueDbPart2, varValueDbPart3, varValueDbPart4);
+  DataConversion::splitDoubleToUint16(varMergeUInt16ToDouble, varValueDbPart1, varValueDbPart2, varValueDbPart3, varValueDbPart4);
   delay(500);
   // Write value to Modbus variable
   mb.Hreg(NR_VALUEDBPART1, varValueDbPart1);
@@ -445,40 +442,40 @@ void loop()
   // Yield to other tasks (if any)
   yield();
 
-  // Read individual bits from the state16bitRegister and store them in corresponding variables
-  bitValue00 = bitRead(state16bitRegister, 0);  // Read bit 0 from state16bitRegister and assign its value to bitValue00
-  bitValue01 = bitRead(state16bitRegister, 1);  // Read bit 1 from state16bitRegister and assign its value to bitValue01
-  bitValue02 = bitRead(state16bitRegister, 2);  // Read bit 2 from state16bitRegister and assign its value to bitValue02
-  bitValue03 = bitRead(state16bitRegister, 3);  // Read bit 3 from state16bitRegister and assign its value to bitValue03
-  bitValue04 = bitRead(state16bitRegister, 4);  // Read bit 4 from state16bitRegister and assign its value to bitValue04
-  bitValue05 = bitRead(state16bitRegister, 5);  // Read bit 5 from state16bitRegister and assign its value to bitValue05
-  bitValue06 = bitRead(state16bitRegister, 6);  // Read bit 6 from state16bitRegister and assign its value to bitValue06
-  bitValue07 = bitRead(state16bitRegister, 7);  // Read bit 7 from state16bitRegister and assign its value to bitValue07
-  bitValue08 = bitRead(state16bitRegister, 8);  // Read bit 8 from state16bitRegister and assign its value to bitValue08
-  bitValue09 = bitRead(state16bitRegister, 9);  // Read bit 9 from state16bitRegister and assign its value to bitValue09
-  bitValue10 = bitRead(state16bitRegister, 10); // Read bit 10 from state16bitRegister and assign its value to bitValue10
-  bitValue11 = bitRead(state16bitRegister, 11); // Read bit 11 from state16bitRegister and assign its value to bitValue11
-  bitValue12 = bitRead(state16bitRegister, 12); // Read bit 12 from state16bitRegister and assign its value to bitValue12
-  bitValue13 = bitRead(state16bitRegister, 13); // Read bit 13 from state16bitRegister and assign its value to bitValue13
-  bitValue14 = bitRead(state16bitRegister, 14); // Read bit 14 from state16bitRegister and assign its value to bitValue14
-  bitValue15 = bitRead(state16bitRegister, 15); // Read bit 15 from state16bitRegister and assign its value to bitValue15
+  // Read individual bits from the state16bitRegister and store them in corresponding variables using DataConversion::readBit()
+  bitValue00 = DataConversion::readBit(state16bitRegister, 0);  // Read bit 0
+  bitValue01 = DataConversion::readBit(state16bitRegister, 1);  // Read bit 1
+  bitValue02 = DataConversion::readBit(state16bitRegister, 2);  // Read bit 2
+  bitValue03 = DataConversion::readBit(state16bitRegister, 3);  // Read bit 3
+  bitValue04 = DataConversion::readBit(state16bitRegister, 4);  // Read bit 4
+  bitValue05 = DataConversion::readBit(state16bitRegister, 5);  // Read bit 5
+  bitValue06 = DataConversion::readBit(state16bitRegister, 6);  // Read bit 6
+  bitValue07 = DataConversion::readBit(state16bitRegister, 7);  // Read bit 7
+  bitValue08 = DataConversion::readBit(state16bitRegister, 8);  // Read bit 8
+  bitValue09 = DataConversion::readBit(state16bitRegister, 9);  // Read bit 9
+  bitValue10 = DataConversion::readBit(state16bitRegister, 10); // Read bit 10
+  bitValue11 = DataConversion::readBit(state16bitRegister, 11); // Read bit 11
+  bitValue12 = DataConversion::readBit(state16bitRegister, 12); // Read bit 12
+  bitValue13 = DataConversion::readBit(state16bitRegister, 13); // Read bit 13
+  bitValue14 = DataConversion::readBit(state16bitRegister, 14); // Read bit 14
+  bitValue15 = DataConversion::readBit(state16bitRegister, 15); // Read bit 15
 
   // The splitUint16ToInt8 function divides a 16-bit unsigned variable into two 8-bit signed variables.
-  dtConv.splitUint16ToInt8(varMergeInt8ToUInt16, varI8a, varI8b);
+  DataConversion::splitUint16ToInt8(varMergeInt8ToUInt16, varI8a, varI8b);
   // The splitUint16ToUint8 function divides a 16-bit unsigned variable into two 8-bit unsigned variables.
-  dtConv.splitUint16ToUint8(varMergeUint8ToUint16, varUi8a, varUi8b);
+  DataConversion::splitUint16ToUint8(varMergeUint8ToUint16, varUi8a, varUi8b);
   // Combines a high word and a low word into a 32-bit integer.
-  varMergeUInt16ToInt32 = dtConv.mergeUint16ToInt32(varValueI32Part1, varValueI32Part2);
+  varMergeUInt16ToInt32 = DataConversion::mergeUint16ToInt32(varValueI32Part1, varValueI32Part2);
   // Combines a high word and a low word into a 32-bit unsigned integer.
-  varMergeUInt16ToUInt32 = dtConv.mergeUint16ToUint32(varValueUi32Part1, varValueUi32Part2);
+  varMergeUInt16ToUInt32 = DataConversion::mergeUint16ToUint32(varValueUi32Part1, varValueUi32Part2);
   // Combines a high word and a low word into a 32-bit float.
-  varMergeUInt16ToFloat32 = dtConv.mergeUint16ToFloat32(varFloatPart1, varFloatPart2);
+  varMergeUInt16ToFloat32 = DataConversion::mergeUint16ToFloat32(varFloatPart1, varFloatPart2);
   // Combines four word into a 64-bit integer.
-  varMergeUInt16ToInt64 = dtConv.mergeUint16ToInt64(varValueI64Part1, varValueI64Part2, varValueI64Part3, varValueI64Part4);
+  varMergeUInt16ToInt64 = DataConversion::mergeUint16ToInt64(varValueI64Part1, varValueI64Part2, varValueI64Part3, varValueI64Part4);
   // Combines four word into a 64-bit unsigned integer.
-  varMergeUInt16ToUInt64 = dtConv.mergeUint16ToUint64(varValueUi64Part1, varValueUi64Part2, varValueUi64Part3, varValueUi64Part4);
+  varMergeUInt16ToUInt64 = DataConversion::mergeUint16ToUint64(varValueUi64Part1, varValueUi64Part2, varValueUi64Part3, varValueUi64Part4);
   // Combines four word into a 64-bit double.
-  varMergeUInt16ToDouble = dtConv.mergeUint16ToDouble(varValueDbPart1, varValueDbPart2, varValueDbPart3, varValueDbPart4);
+  varMergeUInt16ToDouble = DataConversion::mergeUint16ToDouble(varValueDbPart1, varValueDbPart2, varValueDbPart3, varValueDbPart4);
 
   /* *Print the values of the variables* */
   // Get the current time

--- a/src/Examples/NewBitManipulation.ino
+++ b/src/Examples/NewBitManipulation.ino
@@ -1,0 +1,101 @@
+#include <Arduino.h>
+#include <DataConversion.h> // Assuming DataConversion.h is in the library's src directory or accessible
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  Serial.println("DataConversion Library: Bit Manipulation Example");
+  Serial.println("---------------------------------------------");
+
+  uint16_t myWord = 0; // Start with 0 (all bits clear)
+
+  // Initial value
+  Serial.print("Initial word: 0b");
+  for (int i = 15; i >= 0; i--) {
+    Serial.print(DataConversion::readBit(myWord, i));
+  }
+  Serial.println(" (Decimal: " + String(myWord) + ")");
+
+  // Test setBit
+  Serial.println("\nTesting setBit():");
+  myWord = DataConversion::setBit(myWord, 0);  // Set bit 0
+  myWord = DataConversion::setBit(myWord, 7);  // Set bit 7
+  myWord = DataConversion::setBit(myWord, 15); // Set bit 15
+  myWord = DataConversion::setBit(myWord, 7);  // Set bit 7 again (should have no effect)
+  // Attempt to set a bit out of bounds (should be handled gracefully by the function)
+  myWord = DataConversion::setBit(myWord, 16); 
+
+
+  Serial.print("After setBit(0, 7, 15): 0b");
+  for (int i = 15; i >= 0; i--) {
+    Serial.print(DataConversion::readBit(myWord, i));
+  }
+  Serial.println(" (Decimal: " + String(myWord) + ")");
+
+  // Test readBit
+  Serial.println("\nTesting readBit():");
+  Serial.println("Bit 0 is: " + String(DataConversion::readBit(myWord, 0))); // Should be 1
+  Serial.println("Bit 1 is: " + String(DataConversion::readBit(myWord, 1))); // Should be 0
+  Serial.println("Bit 7 is: " + String(DataConversion::readBit(myWord, 7))); // Should be 1
+  Serial.println("Bit 15 is: " + String(DataConversion::readBit(myWord, 15)));// Should be 1
+  // Attempt to read a bit out of bounds
+  Serial.println("Bit 16 is (out of bounds): " + String(DataConversion::readBit(myWord, 16)));
+
+
+  // Test clearBit
+  Serial.println("\nTesting clearBit():");
+  myWord = DataConversion::clearBit(myWord, 7);  // Clear bit 7
+  myWord = DataConversion::clearBit(myWord, 0);  // Clear bit 0
+  myWord = DataConversion::clearBit(myWord, 7);  // Clear bit 7 again (should have no effect)
+  // Attempt to clear a bit out of bounds
+  myWord = DataConversion::clearBit(myWord, 17);
+
+  Serial.print("After clearBit(0, 7): 0b");
+  for (int i = 15; i >= 0; i--) {
+    Serial.print(DataConversion::readBit(myWord, i));
+  }
+  Serial.println(" (Decimal: " + String(myWord) + ")");
+  Serial.println("Bit 7 is now: " + String(DataConversion::readBit(myWord, 7))); // Should be 0
+
+  // Test toggleBit
+  Serial.println("\nTesting toggleBit():");
+  Serial.print("Before toggleBit(5): 0b");
+  for (int i = 15; i >= 0; i--) {
+    Serial.print(DataConversion::readBit(myWord, i));
+  }
+  Serial.println(" (Bit 5 is " + String(DataConversion::readBit(myWord, 5)) + ")");
+  
+  myWord = DataConversion::toggleBit(myWord, 5); // Toggle bit 5 (0 -> 1)
+  
+  Serial.print("After toggleBit(5) (0->1): 0b");
+  for (int i = 15; i >= 0; i--) {
+    Serial.print(DataConversion::readBit(myWord, i));
+  }
+  Serial.println(" (Bit 5 is " + String(DataConversion::readBit(myWord, 5)) + ")");
+
+  myWord = DataConversion::toggleBit(myWord, 5); // Toggle bit 5 again (1 -> 0)
+
+  Serial.print("After toggleBit(5) (1->0): 0b");
+  for (int i = 15; i >= 0; i--) {
+    Serial.print(DataConversion::readBit(myWord, i));
+  }
+  Serial.println(" (Bit 5 is " + String(DataConversion::readBit(myWord, 5)) + ")");
+
+  // Attempt to toggle a bit out of bounds
+  myWord = DataConversion::toggleBit(myWord, 18);
+  Serial.print("After toggleBit(18) (out of bounds): 0b");
+   for (int i = 15; i >= 0; i--) {
+    Serial.print(DataConversion::readBit(myWord, i));
+  }
+  Serial.println(" (Decimal: " + String(myWord) + ")");
+
+
+  Serial.println("\n--- End of Bit Manipulation Example ---");
+}
+
+void loop() {
+  // Nothing to do here for this example
+}

--- a/src/Examples/SplitMergeInt8ToUInt16.ino
+++ b/src/Examples/SplitMergeInt8ToUInt16.ino
@@ -21,9 +21,6 @@
 #include <ModbusIP_ESP8266.h>
 #include <DataConversion.h>
 
-// Create an instance of the DataConversion class
-DataConversion dtConv;
-
 /*
 The enum function is used to create an enumerated data type.
 In this case, it is creating the MbipRegister enumeration type.
@@ -94,7 +91,7 @@ void setup()
   delay(500);
 
   // The mergeUint8ToUint16 function combines two 8-bit unsigned variables into one 16-bit unsigned variable.
-  varMergeInt8ToUInt16 = dtConv.mergeInt8ToUint16(varI8a, varI8b);
+  varMergeInt8ToUInt16 = DataConversion::mergeInt8ToUint16(varI8a, varI8b);
   Serial.println("Value merge varI8a + varI8b ");
   delay(500);
   // Write value to Modbus variable
@@ -130,7 +127,7 @@ void loop()
 
   
   // The splitUint16ToInt8 function divides a 16-bit unsigned variable into two 8-bit signed variables.
-  dtConv.splitUint16ToInt8(varMergeInt8ToUInt16, varI8a, varI8b);
+  DataConversion::splitUint16ToInt8(varMergeInt8ToUInt16, varI8a, varI8b);
   
   /* *Print the values of the variables* */
   // Get the current time

--- a/src/Examples/SplitMergeUint16ToDouble.ino
+++ b/src/Examples/SplitMergeUint16ToDouble.ino
@@ -29,9 +29,6 @@ https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitwrite/
 #include <ModbusIP_ESP8266.h>
 #include <DataConversion.h>
 
-// Create an instance of the DataConversion class
-DataConversion dtConv;
-
 /*
 The enum function is used to create an enumerated data type.
 In this case, it is creating the MbipRegister enumeration type.
@@ -123,7 +120,7 @@ void setup()
   varMergeUInt16ToDouble = -12345.0123456789;
   Serial.println("Write -12345.023456789 in variable varMergeUInt16ToDouble ");
   // Separates a int64 value into four uint16_t values.
-  dtConv.splitDoubleToUint16(varMergeUInt16ToDouble, varValueDbPart1, varValueDbPart2, varValueDbPart3, varValueDbPart4);
+  DataConversion::splitDoubleToUint16(varMergeUInt16ToDouble, varValueDbPart1, varValueDbPart2, varValueDbPart3, varValueDbPart4);
   delay(500);
   // Write value to Modbus variable
   mb.Hreg(NR_VALUEDBPART1, varValueDbPart1);
@@ -166,7 +163,7 @@ void loop()
   yield();
 
   // Combines four word into a 64-bit double.
-  varMergeUInt16ToDouble = dtConv.mergeUint16ToDouble(varValueDbPart1, varValueDbPart2, varValueDbPart3, varValueDbPart4);
+  varMergeUInt16ToDouble = DataConversion::mergeUint16ToDouble(varValueDbPart1, varValueDbPart2, varValueDbPart3, varValueDbPart4);
 
   /* *Print the values of the variables* */
   // Get the current time

--- a/src/Examples/SplitMergeUint16ToFloat32.ino
+++ b/src/Examples/SplitMergeUint16ToFloat32.ino
@@ -29,9 +29,6 @@ https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitwrite/
 #include <ModbusIP_ESP8266.h>
 #include <DataConversion.h>
 
-// Create an instance of the DataConversion class
-DataConversion dtConv;
-
 /*
 The enum function is used to create an enumerated data type.
 In this case, it is creating the MbipRegister enumeration type.
@@ -104,7 +101,7 @@ void setup()
   varMergeUInt16ToFloat32 = 31.12345;
   Serial.println("Write 31.12345 in variable varMergeUInt16ToFloat32 ");
   // Separates a float value into two uint16_t values.
-  dtConv.splitFloat32ToUint16(varMergeUInt16ToFloat32, varFloatPart1, varFloatPart2);
+  DataConversion::splitFloat32ToUint16(varMergeUInt16ToFloat32, varFloatPart1, varFloatPart2);
   delay(500);
   // Write value to Modbus variable
   mb.Hreg(NR_FLOATPART1, varFloatPart1);
@@ -141,7 +138,7 @@ void loop()
   yield();
 
   // Combines a high word and a low word into a 32-bit float.
-  varMergeUInt16ToFloat32 = dtConv.mergeUint16ToFloat32(varFloatPart1, varFloatPart2);
+  varMergeUInt16ToFloat32 = DataConversion::mergeUint16ToFloat32(varFloatPart1, varFloatPart2);
   
   /* *Print the values of the variables* */
   // Get the current time

--- a/src/Examples/SplitMergeUint16ToInt32.ino
+++ b/src/Examples/SplitMergeUint16ToInt32.ino
@@ -29,9 +29,6 @@ https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitwrite/
 #include <ModbusIP_ESP8266.h>
 #include <DataConversion.h>
 
-// Create an instance of the DataConversion class
-DataConversion dtConv;
-
 /*
 The enum function is used to create an enumerated data type.
 In this case, it is creating the MbipRegister enumeration type.
@@ -107,7 +104,7 @@ void setup()
   Serial.println("Write -2147483648 in variable varMergeUInt16ToInt32 ");
 
   // Splits a 32-bit integer into two 16-bit words.
-  dtConv.splitInt32ToUint16(varMergeUInt16ToInt32, varValueI32Part1, varValueI32Part2);
+  DataConversion::splitInt32ToUint16(varMergeUInt16ToInt32, varValueI32Part1, varValueI32Part2);
   delay(500);
   // Write value to Modbus variable
   mb.Hreg(NR_VALUEI32PART1, varValueI32Part1);
@@ -141,7 +138,7 @@ void loop()
   yield();
 
   // Combines a high word and a low word into a 32-bit integer.
-  varMergeUInt16ToInt32 = dtConv.mergeUint16ToInt32(varValueI32Part1, varValueI32Part2);
+  varMergeUInt16ToInt32 = DataConversion::mergeUint16ToInt32(varValueI32Part1, varValueI32Part2);
 
   /* *Print the values of the variables* */
   // Get the current time

--- a/src/Examples/SplitMergeUint16ToInt64.ino
+++ b/src/Examples/SplitMergeUint16ToInt64.ino
@@ -29,9 +29,6 @@ https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitwrite/
 #include <ModbusIP_ESP8266.h>
 #include <DataConversion.h>
 
-// Create an instance of the DataConversion class
-DataConversion dtConv;
-
 /*
 The enum function is used to create an enumerated data type.
 In this case, it is creating the MbipRegister enumeration type.
@@ -115,7 +112,7 @@ void setup()
   varMergeUInt16ToInt64 = -4294967295;
   Serial.println("Write -4294967295 in variable varMergeUInt16ToInt64 ");
   // Separates a int64 value into four uint16_t values.
-  dtConv.splitInt64ToUint16(varMergeUInt16ToInt64, varValueI64Part1, varValueI64Part2, varValueI64Part3, varValueI64Part4);
+  DataConversion::splitInt64ToUint16(varMergeUInt16ToInt64, varValueI64Part1, varValueI64Part2, varValueI64Part3, varValueI64Part4);
   delay(500);
   // Write value to Modbus variable
   mb.Hreg(NR_VALUEI64PART1, varValueI64Part1);
@@ -159,7 +156,7 @@ void loop()
   yield();
 
   // Combines four word into a 64-bit integer.
-  varMergeUInt16ToInt64 = dtConv.mergeUint16ToInt64(varValueI64Part1, varValueI64Part2, varValueI64Part3, varValueI64Part4);
+  varMergeUInt16ToInt64 = DataConversion::mergeUint16ToInt64(varValueI64Part1, varValueI64Part2, varValueI64Part3, varValueI64Part4);
   
   /* *Print the values of the variables* */
   // Get the current time

--- a/src/Examples/SplitMergeUint16ToUint32.ino
+++ b/src/Examples/SplitMergeUint16ToUint32.ino
@@ -29,9 +29,6 @@ https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitwrite/
 #include <ModbusIP_ESP8266.h>
 #include <DataConversion.h>
 
-// Create an instance of the DataConversion class
-DataConversion dtConv;
-
 /*
 The enum function is used to create an enumerated data type.
 In this case, it is creating the MbipRegister enumeration type.
@@ -106,7 +103,7 @@ void setup()
   Serial.println("Write 4294967295 in variable varMergeUInt16ToInt32 ");
 
   // Separates a uint32_t value into two uint16_t values.
-  dtConv.splitUint32ToUint16(varMergeUInt16ToUInt32, varValueUi32Part1, varValueUi32Part2);
+  DataConversion::splitUint32ToUint16(varMergeUInt16ToUInt32, varValueUi32Part1, varValueUi32Part2);
   delay(500);
   // Write value to Modbus variable
   mb.Hreg(NR_VALUEUI32PART1, varValueUi32Part1);
@@ -143,7 +140,7 @@ void loop()
   yield();
 
   // Combines a high word and a low word into a 32-bit unsigned integer.
-  varMergeUInt16ToUInt32 = dtConv.mergeUint16ToUint32(varValueUi32Part1, varValueUi32Part2);
+  varMergeUInt16ToUInt32 = DataConversion::mergeUint16ToUint32(varValueUi32Part1, varValueUi32Part2);
   
   /* *Print the values of the variables* */
   // Get the current time

--- a/src/Examples/SplitMergeUint16ToUint64.ino
+++ b/src/Examples/SplitMergeUint16ToUint64.ino
@@ -29,9 +29,6 @@ https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitwrite/
 #include <ModbusIP_ESP8266.h>
 #include <DataConversion.h>
 
-// Create an instance of the DataConversion class
-DataConversion dtConv;
-
 /*
 The enum function is used to create an enumerated data type.
 In this case, it is creating the MbipRegister enumeration type.
@@ -119,7 +116,7 @@ void setup()
   varMergeUInt16ToUInt64 = 84294967295;
   Serial.println("Write 84294967295 in variable varMergeUInt16ToUInt64 ");
   // Separates a int64 value into four uint16_t values.
-  dtConv.splitUint64ToUint16(varMergeUInt16ToUInt64, varValueUi64Part1, varValueUi64Part2, varValueUi64Part3, varValueUi64Part4);
+  DataConversion::splitUint64ToUint16(varMergeUInt16ToUInt64, varValueUi64Part1, varValueUi64Part2, varValueUi64Part3, varValueUi64Part4);
   delay(500);
   // Write value to Modbus variable
   mb.Hreg(NR_VALUEUI64PART1, varValueUi64Part1);
@@ -174,7 +171,7 @@ void loop()
   yield();
 
   // Combines four word into a 64-bit unsigned integer.
-  varMergeUInt16ToUInt64 = dtConv.mergeUint16ToUint64(varValueUi64Part1, varValueUi64Part2, varValueUi64Part3, varValueUi64Part4);
+  varMergeUInt16ToUInt64 = DataConversion::mergeUint16ToUint64(varValueUi64Part1, varValueUi64Part2, varValueUi64Part3, varValueUi64Part4);
   
   /* *Print the values of the variables* */
   // Get the current time

--- a/src/Examples/SplitMergeUint8ToUint16.ino
+++ b/src/Examples/SplitMergeUint8ToUint16.ino
@@ -29,9 +29,6 @@ https://www.arduino.cc/reference/en/language/functions/bits-and-bytes/bitwrite/
 #include <ModbusIP_ESP8266.h>
 #include <DataConversion.h>
 
-// Create an instance of the DataConversion class
-DataConversion dtConv;
-
 /*
 The enum function is used to create an enumerated data type.
 In this case, it is creating the MbipRegister enumeration type.
@@ -105,7 +102,7 @@ void setup()
   delay(500);
 
   // The mergeUint8ToUint16 function combines two 8-bit unsigned variables into one 16-bit unsigned variable.
-  varMergeUint8ToUint16 = dtConv.mergeUint8ToUint16(varUi8a, varUi8b);
+  varMergeUint8ToUint16 = DataConversion::mergeUint8ToUint16(varUi8a, varUi8b);
   Serial.println("Value merge varUi8a + varUi8b ");
   delay(500);
   // Write value to Modbus variable
@@ -139,7 +136,7 @@ void loop()
   yield();
 
   // The splitUint16ToUint8 function divides a 16-bit unsigned variable into two 8-bit unsigned variables.
-  dtConv.splitUint16ToUint8(varMergeUint8ToUint16, varUi8a, varUi8b);
+  DataConversion::splitUint16ToUint8(varMergeUint8ToUint16, varUi8a, varUi8b);
   
   /* *Print the values of the variables* */
   // Get the current time

--- a/src/keywords.txt
+++ b/src/keywords.txt
@@ -14,3 +14,7 @@ mergeUint16ToUint64     KEYWORD1
 splitUint64ToUint16     KEYWORD1
 mergeUint16ToDouble     KEYWORD1
 splitDoubleToUint16     KEYWORD1
+setBit                  KEYWORD1
+clearBit                KEYWORD1
+readBit                 KEYWORD1
+toggleBit               KEYWORD1

--- a/src/library.properties
+++ b/src/library.properties
@@ -7,3 +7,4 @@ paragraph=This library provides functions to merge and split various data types,
 category=Data Manipulation
 url=https://github.com/Merdock1/DataConversion
 architectures=*
+license=MIT


### PR DESCRIPTION
This commit introduces several enhancements and a major documentation update:

New Features:
- Added platform-independent bit manipulation functions to `DataConversion`:
  - `setBit(uint16_t data, uint8_t bitPosition)`
  - `clearBit(uint16_t data, uint8_t bitPosition)`
  - `readBit(uint16_t data, uint8_t bitPosition)`
  - `toggleBit(uint16_t data, uint8_t bitPosition)`
- Added `NewBitManipulation.ino` example for these functions.
- Updated `keywords.txt` for new functions.

Documentation Overhaul:
- Translated `src/README_es.md` to English and made it the primary `README.md`.
- Restructured `README.md` with comprehensive sections:
  - Overview, Features, Modbus Data Representation, Installation, Usage, API Reference, Examples, Bit-level Operations, Contributing, License.
- Corrected Markdown table formatting and image paths.
- Clarified Big Endian word order vs. byte order assumptions.
- Documented new bit manipulation functions and their usage.
- Added MIT License (`LICENSE` file) and updated `library.properties`.

Example Updates:
- Refactored all examples to use `DataConversion::methodName()` static call style.
- Updated `BitTo16bitRegister.ino` and `ExampleAll.ino` to demonstrate and utilize the new library-provided bit manipulation functions.

This significantly improves the library's functionality for bitwise operations and provides clear, comprehensive documentation for you.